### PR TITLE
fix: prevent infinite refetch loop on /bot page

### DIFF
--- a/web/src/hooks/useBotConfig.ts
+++ b/web/src/hooks/useBotConfig.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { doFetch, Method } from "../service/doFetch";
 import { useStore } from "../store";
 
@@ -14,7 +14,7 @@ export function useBotConfig() {
   const apiBaseUrl = useStore((state) => state.apiBaseUrl);
   const scToken = useStore((state) => state.scToken);
 
-  const fetchConfig = async () => {
+  const fetchConfig = useCallback(async () => {
     try {
       setLoading(true);
       const searchParams = new URLSearchParams();
@@ -34,7 +34,7 @@ export function useBotConfig() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [apiBaseUrl, managing, scToken]);
 
   const updateConfig = async (updates: Partial<BotConfig>) => {
     try {


### PR DESCRIPTION
## Summary
- Fixed infinite API refetch loop on the /bot page by wrapping `fetchConfig` in `useCallback` with proper dependencies

## Details
The `/bot` page was experiencing an infinite loading state and continuously refetching the config API endpoint. This was caused by the `fetchConfig` function in `useBotConfig.ts` being recreated on every render, which triggered the `useEffect` dependency array to detect a change and refetch infinitely.

### Changes
- Added `useCallback` wrapper around `fetchConfig` in `web/src/hooks/useBotConfig.ts`
- Added proper dependency array: `[apiBaseUrl, managing, scToken]`
- Now the function only recreates when those dependencies actually change

## Test plan
- [x] Visit `/bot` page
- [x] Verify page loads without infinite loading spinner
- [x] Verify API is only called once on mount
- [x] Verify toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)